### PR TITLE
feat: allow arbitrary keymaps

### DIFF
--- a/lua/whichkey_setup.lua
+++ b/lua/whichkey_setup.lua
@@ -80,6 +80,7 @@ M.register_keymap = function(leader_type, keymap, opts)
     opts = handle_user_opts(opts)
     local bufnr = opts.bufnr
     opts.bufnr = nil
+    local mapkey = leader_type
     local mode, key, mapped_key
     if (leader_type == 'leader') then
         mode = 'n'
@@ -102,9 +103,10 @@ M.register_keymap = function(leader_type, keymap, opts)
         if mode == nil then mode = 'n' end
         key = leader_type
         mapped_key = leader_type
+        mapkey = leader_type .. mode
     end
-    if textmaps[leader_type] == nil then textmaps[leader_type] = {} end
-    local textmap = textmaps[leader_type]
+    if textmaps[mapkey] == nil then textmaps[mapkey] = {} end
+    local textmap = textmaps[mapkey]
     setup_keymap(mode, {key}, keymap, textmap, opts, bufnr)
 
     -- TODO at the moment we register with whichkey plugin everytime

--- a/lua/whichkey_setup.lua
+++ b/lua/whichkey_setup.lua
@@ -98,8 +98,12 @@ M.register_keymap = function(leader_type, keymap, opts)
         key = '<Localleader>'
         mapped_key = '<LocalVisualBindings>'
     else
-        vim.cmd('echoerr "Unknown map type '..leader_type..'"')
+        mode = opts.mode
+        if mode == nil then mode = 'n' end
+        key = leader_type
+        mapped_key = leader_type
     end
+    if textmaps[leader_type] == nil then textmaps[leader_type] = {} end
     local textmap = textmaps[leader_type]
     setup_keymap(mode, {key}, keymap, textmap, opts, bufnr)
 


### PR DESCRIPTION
This PR allows to add arbitrary keymaps (see #8).

For example to setup `goto` keyboard shortcuts for `lsp`:

```lua
local keymap_goto = {
    name = "+goto",
    h = { "<cmd>lua require'lspsaga.provider'.lsp_finder()<CR>", "References" },
    d = { "<cmd>lua require'lspsaga.provider'.preview_definition()<CR>", "Peek Definition" },
    D = { "<Cmd>lua vim.lsp.buf.definition()<CR>", "Goto Definition" },
    s = { "<cmd>lua require('lspsaga.signaturehelp').signature_help()<CR>", "Signature Help" },
    i = { "<cmd>lua vim.lsp.buf.implementation()<CR>", "Goto Implementation" }
  }

wk.register_keymap("g", keymap_goto, { noremap = true, silent = true, bufnr = bufnr })
```